### PR TITLE
Create Prompts List Activity and its navigation action 

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -749,6 +749,12 @@
             android:label="@string/qrcode_auth_flow"
             android:theme="@style/WordPress.NoActionBar"/>
 
+        <!-- Blogging Prompts -->
+        <activity
+            android:name=".ui.bloggingprompts.BloggingPromptsActivity"
+            android:label="@string/blogging_prompts_title"
+            android:theme="@style/WordPress.NoActionBar"/>
+
         <!-- Services -->
         <service
             android:name=".ui.uploads.UploadService"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -45,6 +45,7 @@ import org.wordpress.android.ui.accounts.PostSignupInterstitialActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
 import org.wordpress.android.ui.activitylog.detail.ActivityLogDetailActivity;
 import org.wordpress.android.ui.activitylog.list.ActivityLogListActivity;
+import org.wordpress.android.ui.bloggingprompts.BloggingPromptsActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsActivity;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentsDetailsActivity;
 import org.wordpress.android.ui.debug.cookies.DebugCookiesActivity;
@@ -1750,5 +1751,9 @@ public class ActivityLauncher {
         taskStackBuilder.addNextIntent(qrcodeAuthFlowIntent);
 
         taskStackBuilder.startActivities();
+    }
+
+    public static void viewMorePrompts(@NonNull Context context, SiteModel site) {
+        BloggingPromptsActivity.start(context, site);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -1,0 +1,76 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.MenuItem
+import org.wordpress.android.WordPress
+import org.wordpress.android.databinding.BloggingPromptsListActivityBinding
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.ui.LocaleAwareActivity
+import org.wordpress.android.util.AppLog
+
+class BloggingPromptsActivity : LocaleAwareActivity() {
+
+    private lateinit var site: SiteModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(BloggingPromptsListActivityBinding.inflate(layoutInflater).root)
+
+        site = if (savedInstanceState == null) {
+            checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
+                "SiteModel cannot be null, check the PendingIntent starting BloggingPromptsActivity"
+            }
+        } else {
+            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        if (!intent.hasExtra(WordPress.SITE)) {
+            AppLog.e(AppLog.T.MY_SITE_DASHBOARD, "BloggingPromptsActivity started without a site.")
+            finish()
+            return
+        }
+        restartWhenSiteHasChanged(intent)
+        super.onNewIntent(intent)
+    }
+
+    private fun restartWhenSiteHasChanged(intent: Intent) {
+        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
+        if (site.id != this.site.id) {
+            finish()
+            startActivity(intent)
+            return
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        @JvmOverloads
+        fun start(
+            context: Context,
+            site: SiteModel,
+        ) = context.startActivity(buildIntent(context, site))
+
+        @JvmStatic
+        @JvmOverloads
+        fun buildIntent(
+            context: Context,
+            site: SiteModel,
+        ) = Intent(context, BloggingPromptsActivity::class.java).apply {
+            putExtra(WordPress.SITE, site)
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -11,7 +11,6 @@ import org.wordpress.android.ui.LocaleAwareActivity
 import org.wordpress.android.util.AppLog
 
 class BloggingPromptsActivity : LocaleAwareActivity() {
-
     private lateinit var site: SiteModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,7 +55,6 @@ class BloggingPromptsActivity : LocaleAwareActivity() {
     }
 
     companion object {
-
         @JvmStatic
         @JvmOverloads
         fun start(

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -8,7 +8,6 @@ import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.BloggingPromptsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.LocaleAwareActivity
-import org.wordpress.android.util.AppLog
 
 class BloggingPromptsActivity : LocaleAwareActivity() {
     private lateinit var site: SiteModel
@@ -20,7 +19,7 @@ class BloggingPromptsActivity : LocaleAwareActivity() {
 
         site = if (savedInstanceState == null) {
             checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                "SiteModel cannot be null, check the PendingIntent starting BloggingPromptsActivity"
+                "${WordPress.SITE} argument cannot be null, check the PendingIntent starting ${BloggingPromptsActivity::class.simpleName}"
             }
         } else {
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
@@ -33,25 +32,6 @@ class BloggingPromptsActivity : LocaleAwareActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        if (!intent.hasExtra(WordPress.SITE)) {
-            AppLog.e(AppLog.T.MY_SITE_DASHBOARD, "BloggingPromptsActivity started without a site.")
-            finish()
-            return
-        }
-        restartWhenSiteHasChanged(intent)
-        super.onNewIntent(intent)
-    }
-
-    private fun restartWhenSiteHasChanged(intent: Intent) {
-        val site = intent.getSerializableExtra(WordPress.SITE) as SiteModel
-        if (site.id != this.site.id) {
-            finish()
-            startActivity(intent)
-            return
-        }
     }
 
     companion object {

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
 import org.wordpress.android.WordPress
 import org.wordpress.android.databinding.BloggingPromptsListActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.LocaleAwareActivity
 
-class BloggingPromptsActivity : LocaleAwareActivity() {
+class BloggingPromptsActivity : AppCompatActivity() {
     private lateinit var site: SiteModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,7 +19,7 @@ class BloggingPromptsActivity : LocaleAwareActivity() {
 
         site = if (savedInstanceState == null) {
             checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                "${WordPress.SITE} argument cannot be null, check the PendingIntent starting ${BloggingPromptsActivity::class.simpleName}"
+                "${WordPress.SITE} argument cannot be null, when launching ${BloggingPromptsActivity::class.simpleName}"
             }
         } else {
             savedInstanceState.getSerializable(WordPress.SITE) as SiteModel

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItem.kt
@@ -222,7 +222,8 @@ sealed class MySiteCardAndItem(open val type: Type, open val activeQuickStartIte
                         val attribution: BloggingPromptAttribution,
                         val onShareClick: (String) -> Unit,
                         val onAnswerClick: (PromptID) -> Unit,
-                        val onSkipClick: () -> Unit
+                        val onSkipClick: () -> Unit,
+                        val onViewMorePrompts: () -> Unit
                     ) : BloggingPromptCard(dashboardCardType = DashboardCardType.BLOGGING_PROMPT_CARD)
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteCardAndItemBuilderParams.kt
@@ -95,6 +95,7 @@ sealed class MySiteCardAndItemBuilderParams {
         val bloggingPrompt: BloggingPromptModel?,
         val onShareClick: (message: String) -> Unit,
         val onAnswerClick: (promptId: Int) -> Unit,
-        val onSkipClick: () -> Unit
+        val onSkipClick: () -> Unit,
+        val onViewMorePrompts: () -> Unit
     ) : MySiteCardAndItemBuilderParams()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/MySiteViewModel.kt
@@ -461,7 +461,8 @@ class MySiteViewModel @Inject constructor(
                                 } else null,
                                 onShareClick = this::onBloggingPromptShareClick,
                                 onAnswerClick = this::onBloggingPromptAnswerClick,
-                                onSkipClick = this::onBloggingPromptSkipClicked
+                                onSkipClick = this::onBloggingPromptSkipClicked,
+                                onViewMorePrompts = this::onBloggingPromptViewMorePrompts
                         )
                 ),
                 QuickLinkRibbonBuilderParams(
@@ -1234,6 +1235,12 @@ class MySiteViewModel @Inject constructor(
             )
 
             _onSnackbarMessage.postValue(Event(snackbar))
+        }
+    }
+
+    private fun onBloggingPromptViewMorePrompts() {
+        selectedSiteRepository.getSelectedSite()?.let { site ->
+            _onNavigation.postValue(Event(SiteNavigationAction.ViewMorePrompts(site)))
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/SiteNavigationAction.kt
@@ -78,5 +78,6 @@ sealed class SiteNavigationAction {
     data class EditScheduledPost(val site: SiteModel, val postId: Int) : SiteNavigationAction()
     data class OpenStatsInsights(val site: SiteModel) : SiteNavigationAction()
     data class OpenTodaysStatsGetMoreViewsExternalUrl(val url: String) : SiteNavigationAction()
+    data class ViewMorePrompts(val site: SiteModel) : SiteNavigationAction()
     object OpenJetpackPoweredBottomSheet : SiteNavigationAction()
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilder.kt
@@ -32,7 +32,8 @@ class BloggingPromptCardBuilder @Inject constructor() {
                 attribution = BloggingPromptAttribution.fromString(params.bloggingPrompt.attribution),
                 onShareClick = params.onShareClick,
                 onAnswerClick = params.onAnswerClick,
-                onSkipClick = params.onSkipClick
+                onSkipClick = params.onSkipClick,
+                onViewMorePrompts = params.onViewMorePrompts
         )
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardViewHolder.kt
@@ -92,7 +92,10 @@ class BloggingPromptCardViewHolder(
         val quickStartPopupMenu = PopupMenu(bloggingPromptCardMenu.context, bloggingPromptCardMenu)
         quickStartPopupMenu.setOnMenuItemClickListener {
             when (it.itemId) {
-                R.id.view_more -> bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
+                R.id.view_more -> {
+                    bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuViewMorePromptsClicked()
+                    card.onViewMorePrompts.invoke()
+                }
                 R.id.skip -> {
                     bloggingPromptsCardAnalyticsTracker.trackMySiteCardMenuSkipThisPromptClicked()
                     card.onSkipClick.invoke()

--- a/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/mysite/tabs/MySiteTabFragment.kt
@@ -361,6 +361,8 @@ class MySiteTabFragment : Fragment(R.layout.my_site_tab_fragment),
             ActivityLauncher.viewBlogStatsForTimeframe(requireActivity(), action.site, StatsTimeframe.INSIGHTS)
         is SiteNavigationAction.OpenTodaysStatsGetMoreViewsExternalUrl ->
             ActivityLauncher.openUrlExternal(requireActivity(), action.url)
+        is SiteNavigationAction.ViewMorePrompts ->
+            ActivityLauncher.viewMorePrompts(requireActivity(), action.site)
         is SiteNavigationAction.OpenJetpackPoweredBottomSheet -> showJetpackPoweredBottomSheet()
     }
 

--- a/WordPress/src/main/res/layout/blogging_prompts_list_activity.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_activity.xml
@@ -8,5 +8,5 @@
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-    <!-- TODO: android:name -->
+
 </FrameLayout>

--- a/WordPress/src/main/res/layout/blogging_prompts_list_activity.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_activity.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+    <!-- TODO: android:name -->
+</FrameLayout>

--- a/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
+++ b/WordPress/src/main/res/menu/blogging_prompt_card_menu.xml
@@ -4,7 +4,7 @@
         <item
             android:id="@+id/view_more"
             android:title="@string/my_site_blogging_prompt_card_menu_view_more"
-            android:visible="false" />
+            android:visible="true" />
         <item
             android:id="@+id/skip"
             android:title="@string/my_site_blogging_prompt_card_menu_skip" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4102,6 +4102,7 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_answer_prompt_notification_title">Daily Prompt</string>
     <string name="blogging_prompts_answer_prompt_notification_answer_action">Answer</string>
     <string name="blogging_prompts_notification_dismiss">Dismiss</string>
+    <string name="blogging_prompts_title">Prompts</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/MySiteViewModelTest.kt
@@ -251,6 +251,7 @@ class MySiteViewModelTest : BaseUnitTest() {
     private var onBloggingPromptShareClicked: ((message: String) -> Unit)? = null
     private var onBloggingPromptAnswerClicked: ((promptId: Int) -> Unit)? = null
     private var onBloggingPromptSkipClicked: (() -> Unit)? = null
+    private var onBloggingPromptViewMoreClicked: (() -> Unit)? = null
     private val quickStartCategory: QuickStartCategory
         get() = QuickStartCategory(
                 taskType = QuickStartTaskType.CUSTOMIZE,
@@ -1655,6 +1656,17 @@ class MySiteViewModelTest : BaseUnitTest() {
     }
 
     @Test
+    fun `given blogging prompt card, when view more prompts button is clicked, open prompt list page`() {
+        initSelectedSite()
+
+        requireNotNull(onBloggingPromptViewMoreClicked).invoke()
+
+        assertThat(navigationActions).containsOnly(
+                SiteNavigationAction.ViewMorePrompts(site)
+        )
+    }
+
+    @Test
     fun `given blogging prompt card, when skip button is clicked, prompt is skipped and undo snackbar displayed`() =
             test {
                 initSelectedSite()
@@ -2956,6 +2968,7 @@ class MySiteViewModelTest : BaseUnitTest() {
         onBloggingPromptShareClicked = params.bloggingPromptCardBuilderParams.onShareClick
         onBloggingPromptAnswerClicked = params.bloggingPromptCardBuilderParams.onAnswerClick
         onBloggingPromptSkipClicked = params.bloggingPromptCardBuilderParams.onSkipClick
+        onBloggingPromptViewMoreClicked = params.bloggingPromptCardBuilderParams.onViewMorePrompts
         return BloggingPromptCardWithData(
                 prompt = UiStringText("Test prompt"),
                 respondents = emptyList(),
@@ -2965,7 +2978,8 @@ class MySiteViewModelTest : BaseUnitTest() {
                 attribution = BloggingPromptAttribution.DAY_ONE,
                 onShareClick = onBloggingPromptShareClicked as ((message: String) -> Unit),
                 onAnswerClick = onBloggingPromptAnswerClicked as ((promptId: Int) -> Unit),
-                onSkipClick = onBloggingPromptSkipClicked as (() -> Unit)
+                onSkipClick = onBloggingPromptSkipClicked as (() -> Unit),
+                onViewMorePrompts = onBloggingPromptViewMoreClicked as (() -> Unit)
         )
     }
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/CardsBuilderTest.kt
@@ -188,7 +188,7 @@ class CardsBuilderTest {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), mock(), mock(), mock(), mock()
                         )
                 ),
                 quickLinkRibbonBuilderParams = QuickLinkRibbonBuilderParams(

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/CardsBuilderTest.kt
@@ -200,7 +200,7 @@ class CardsBuilderTest : BaseUnitTest() {
                         todaysStatsCardBuilderParams = TodaysStatsCardBuilderParams(mock(), mock(), mock(), mock()),
                         postCardBuilderParams = PostCardBuilderParams(mock(), mock(), mock()),
                         bloggingPromptCardBuilderParams = BloggingPromptCardBuilderParams(
-                                mock(), mock(), mock(), mock()
+                                mock(), mock(), mock(), mock(), mock()
                         )
                 )
         )

--- a/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/mysite/cards/dashboard/bloggingprompts/BloggingPromptCardBuilderTest.kt
@@ -84,12 +84,13 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
     }
 
     private fun buildBloggingPromptCard(bloggingPrompt: BloggingPromptModel?) = builder.build(
-            BloggingPromptCardBuilderParams(bloggingPrompt, onShareClick, onAnswerClick, onSkipClick)
+            BloggingPromptCardBuilderParams(bloggingPrompt, onShareClick, onAnswerClick, onSkipClick, onViewMorePrompts)
     )
 
     private val onShareClick: (message: String) -> Unit = { }
     private val onAnswerClick: (promptId: Int) -> Unit = { }
     private val onSkipClick: () -> Unit = { }
+    private val onViewMorePrompts: () -> Unit = { }
 
     private val bloggingPromptCard = BloggingPromptCardWithData(
             prompt = UiStringText(PROMPT_TITLE),
@@ -100,6 +101,7 @@ class BloggingPromptCardBuilderTest : BaseUnitTest() {
             onShareClick = onShareClick,
             onAnswerClick = onAnswerClick,
             attribution = BloggingPromptAttribution.DAY_ONE,
-            onSkipClick = onSkipClick
+            onSkipClick = onSkipClick,
+            onViewMorePrompts = onViewMorePrompts
     )
 }


### PR DESCRIPTION
Fixes #17125

**NOTE: This PR should not be merged into `trunk` yet. This is one small part of the task.** 

**To test**
- Menu options under Prompts card
- Clicking "View more prompts" should open activity, PromptsActivity

| Image  | Description |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/2140539/193133604-443b3787-bcc1-4ff7-aaa6-74e4055d8217.png)  | Screenshot of the Home screen once the site is selected. A new menu option has been added to the Prompts card, "View more options" which will lead to a newly created Prompts List Activity (currently blank)  |


## Regression Notes
**1. Potential unintended areas of impact**
  - Changes to test classes depending on Prompt Dashboard card

**2. What I did to test those areas of impact (or what existing automated tests I relied on)**
  - Manual test to ensure the click listener for menu option "View More Prompts" is working as expected.
  - Manual test to ensure the Prompts List Activity opens on clicking "View More Prompts" screen (currently blank)
  - Manual test to ensure that the other menu options ("Skip", "Learn more") work as before.
  - Run existing unit tests to ensure there is no regression

**3. What automated tests I added (or what prevented me from doing so)**
  - Unit tests to ensure the click listener for "View More Prompts" is handled in ViewModel.


## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

