### PR TITLE
Add swipable tabbed layout to Prompts List Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import org.wordpress.android.WordPress
-import org.wordpress.android.databinding.BloggingPromptsListActivityBinding
+import org.wordpress.android.databinding.BloggingPromptsActivityBinding
 import org.wordpress.android.fluxc.model.SiteModel
 
 class BloggingPromptsActivity : AppCompatActivity() {
@@ -14,15 +14,11 @@ class BloggingPromptsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val binding = BloggingPromptsActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setContentView(BloggingPromptsListActivityBinding.inflate(layoutInflater).root)
-
-        site = if (savedInstanceState == null) {
-            checkNotNull(intent.getSerializableExtra(WordPress.SITE) as? SiteModel) {
-                "${WordPress.SITE} argument cannot be null, when launching ${BloggingPromptsActivity::class.simpleName}"
-            }
-        } else {
-            savedInstanceState.getSerializable(WordPress.SITE) as SiteModel
+        site = checkNotNull((intent.getSerializableExtra(WordPress.SITE) as? SiteModel)) {
+            "${WordPress.SITE} argument cannot be null, when launching ${BloggingPromptsActivity::class.simpleName}"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
@@ -1,0 +1,39 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.wordpress.android.databinding.BloggingPromptsListFragmentBinding
+import org.wordpress.android.ui.ViewPagerFragment
+
+class BloggingPromptsListFragment : ViewPagerFragment() {
+    private lateinit var binding: BloggingPromptsListFragmentBinding
+
+    override fun getScrollableViewForUniqueIdProvision(): View = binding.tempText
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = BloggingPromptsListFragmentBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val section = arguments?.getSerializable(LIST_TYPE) as? PromptSection
+                ?: PromptSection.ALL
+        binding.tempText.text = section.name
+    }
+
+    companion object {
+        const val LIST_TYPE = "type_key"
+
+        fun newInstance(section: PromptSection): BloggingPromptsListFragment {
+            val fragment = BloggingPromptsListFragment()
+            val bundle = Bundle()
+            bundle.putSerializable(LIST_TYPE, section)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentFragment.kt
@@ -1,0 +1,107 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import com.google.android.material.tabs.TabLayout.Tab
+import com.google.android.material.tabs.TabLayoutMediator
+import org.wordpress.android.R
+import org.wordpress.android.databinding.BloggingPromptsParentFragmentBinding
+import org.wordpress.android.ui.bloggingprompts.PromptSection.ALL
+import org.wordpress.android.ui.bloggingprompts.PromptSection.ANSWERED
+import org.wordpress.android.ui.bloggingprompts.PromptSection.NOT_ANSWERED
+
+class BloggingPromptsParentFragment : Fragment() {
+    private lateinit var binding: BloggingPromptsParentFragmentBinding
+
+    private val viewModel: BloggingPromptsParentViewModel by activityViewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = BloggingPromptsParentFragmentBinding.inflate(inflater)
+        setupToolbar(binding)
+        setupTabLayout(binding)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.onOpen()
+    }
+
+    private fun setupToolbar(binding: BloggingPromptsParentFragmentBinding) {
+        with(binding) {
+            with(activity as AppCompatActivity) {
+                setSupportActionBar(toolbar)
+
+                title = getString(R.string.blogging_prompts_title)
+                supportActionBar?.setDisplayShowTitleEnabled(true)
+                supportActionBar?.setDisplayHomeAsUpEnabled(true)
+            }
+        }
+    }
+
+    private fun setupTabLayout(binding: BloggingPromptsParentFragmentBinding) {
+        with(binding) {
+            val adapter = BloggingPromptsPagerAdapter(this@BloggingPromptsParentFragment)
+            promptPager.adapter = adapter
+            TabLayoutMediator(tabLayout, promptPager) { tab, position ->
+                tab.text = adapter.getTabTitle(position)
+            }.attach()
+            tabLayout.addOnTabSelectedListener(SelectedTabListener(viewModel))
+        }
+    }
+
+    companion object {
+        const val LIST_TYPE = "type_key"
+
+        fun newInstance(section: PromptSection): BloggingPromptsParentFragment {
+            val fragment = BloggingPromptsParentFragment()
+            val bundle = Bundle()
+            bundle.putSerializable(LIST_TYPE, section)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+}
+
+private val promptsSections = listOf(ALL, ANSWERED, NOT_ANSWERED)
+
+enum class PromptSection(@StringRes val titleRes: Int) {
+    ALL(R.string.blogging_prompts_tab_all),
+    ANSWERED(R.string.blogging_prompts_tab_answered),
+    NOT_ANSWERED(R.string.blogging_prompts_tab_not_answered)
+}
+
+class BloggingPromptsPagerAdapter(private val parent: BloggingPromptsParentFragment) : FragmentStateAdapter(parent) {
+    override fun getItemCount(): Int = promptsSections.size
+
+    override fun createFragment(position: Int): Fragment {
+        return BloggingPromptsListFragment.newInstance(promptsSections[position])
+    }
+
+    fun getTabTitle(position: Int): CharSequence {
+        return parent.context?.getString(promptsSections[position].titleRes).orEmpty()
+    }
+}
+
+private class SelectedTabListener(val viewModel: BloggingPromptsParentViewModel) : OnTabSelectedListener {
+    override fun onTabReselected(tab: Tab?) = Unit
+
+    override fun onTabUnselected(tab: Tab?) = Unit
+
+    override fun onTabSelected(tab: Tab) {
+        viewModel.onSectionSelected(promptsSections[tab.position])
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsParentViewModel.kt
@@ -1,0 +1,10 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import androidx.lifecycle.ViewModel
+
+class BloggingPromptsParentViewModel : ViewModel() {
+    fun onOpen() = Unit
+
+    @Suppress("UnusedPrivateMember")
+    fun onSectionSelected(promptSection: PromptSection) = Unit
+}

--- a/WordPress/src/main/res/layout/blogging_prompts_activity.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_activity.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.fragment.app.FragmentContainerView
+    <fragment
         android:id="@+id/fragment_container"
+        android:name="org.wordpress.android.ui.bloggingprompts.BloggingPromptsParentFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/temp_text"
+        android:layout_width="wrap_content"
+        android:layout_gravity="center"
+        android:layout_height="wrap_content"
+        tools:text="PROMPTS LIST PAGE" />
+
+</FrameLayout>

--- a/WordPress/src/main/res/layout/blogging_prompts_parent_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_parent_fragment.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/promptPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            app:layout_collapseMode="pin"
+            app:layout_scrollFlags="scroll|enterAlways"
+            android:layout_height="?attr/actionBarSize"
+            app:theme="@style/WordPress.ActionBar" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_marginBottom="0dp"
+            android:background="@drawable/bottom_divider_background"
+            app:tabGravity="fill"
+            app:tabMode="scrollable" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4103,6 +4103,9 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_answer_prompt_notification_answer_action">Answer</string>
     <string name="blogging_prompts_notification_dismiss">Dismiss</string>
     <string name="blogging_prompts_title">Prompts</string>
+    <string name="blogging_prompts_tab_all">All</string>
+    <string name="blogging_prompts_tab_answered">Answered</string>
+    <string name="blogging_prompts_tab_not_answered">Not Answered</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>


### PR DESCRIPTION
Fixes #17125 

**To test:**
- _Follow test instructions as explained in previous PR #2_ 
- Click on a tab to move to the correct fragment
- Swipe left and right to switch tabs
- Click back button on toolbar to close page
- Ensure the screen is retained on screen rotation

| Screenshot 1 | Screenshot 2 |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/2140539/193653570-91f7c804-0835-4ce6-bf0e-9fe50ac9260a.png)|  ![image](https://user-images.githubusercontent.com/2140539/193653882-ca8b3bcc-f12f-46a2-b286-2101f6b8b938.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- No Unit Tests were added since it was a pure UI change


3. What automated tests I added (or what prevented me from doing so)
- No Unit Tests were added since it was a pure UI change

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.