### PR TITLE
Add Loading, Error, Empty states to Prompts List Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
@@ -4,8 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import org.wordpress.android.R
 import org.wordpress.android.databinding.BloggingPromptsListFragmentBinding
 import org.wordpress.android.ui.ViewPagerFragment
+import org.wordpress.android.util.extensions.exhaustive
+import org.wordpress.android.util.extensions.setVisible
+import java.util.concurrent.TimeUnit
 
 class BloggingPromptsListFragment : ViewPagerFragment() {
     private lateinit var binding: BloggingPromptsListFragmentBinding
@@ -23,6 +27,100 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
         val section = arguments?.getSerializable(LIST_TYPE) as? PromptSection
                 ?: PromptSection.ALL
         binding.tempText.text = section.name
+        showContent()
+
+        // DUMMY LOGIC
+        showLoading()
+        binding.root.postDelayed(Runnable {
+            if (!isAdded) return@Runnable
+            when (section) {
+                PromptSection.ALL -> showEmpty()
+                PromptSection.NOT_ANSWERED -> showError()
+                PromptSection.ANSWERED -> showNoConnection()
+            }.exhaustive
+        }, TimeUnit.SECONDS.toMillis(2))
+    }
+
+    private fun showContent() {
+        with(binding) {
+            tempText.setVisible(true)
+            actionableEmptyView.setVisible(false)
+        }
+    }
+
+    private fun showEmpty() {
+        with(binding) {
+            tempText.setVisible(false)
+            with(actionableEmptyView) {
+                setVisible(true)
+                image.apply {
+                    setVisible(true)
+                    setImageResource(R.drawable.img_illustration_empty_results_216dp)
+                }
+                title.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_empty_title)
+                }
+                subtitle.setVisible(false)
+            }
+        }
+    }
+
+    private fun showError() {
+        with(binding) {
+            tempText.setVisible(false)
+            with(actionableEmptyView) {
+                setVisible(true)
+                image.apply {
+                    setVisible(true)
+                    setImageResource(R.drawable.img_illustration_empty_results_216dp)
+                }
+                title.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_error_title)
+                }
+                subtitle.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_error_subtitle)
+                }
+            }
+        }
+    }
+
+    private fun showNoConnection() {
+        with(binding) {
+            tempText.setVisible(false)
+            with(actionableEmptyView) {
+                setVisible(true)
+                image.apply {
+                    setVisible(true)
+                    setImageResource(R.drawable.img_illustration_cloud_off_152dp)
+                }
+                title.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_no_connection_title)
+                }
+                subtitle.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_no_connection_subtitle)
+                }
+            }
+        }
+    }
+
+    fun showLoading() {
+        with(binding) {
+            tempText.setVisible(false)
+            with(actionableEmptyView) {
+                setVisible(true)
+                image.setVisible(false)
+                title.apply {
+                    setVisible(true)
+                    setText(R.string.blogging_prompts_state_loading_title)
+                }
+                subtitle.setVisible(false)
+            }
+        }
     }
 
     companion object {

--- a/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
@@ -6,11 +6,23 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!-- Content -->
     <TextView
         android:id="@+id/temp_text"
         android:layout_width="wrap_content"
-        android:layout_gravity="center"
         android:layout_height="wrap_content"
+        android:layout_gravity="center"
         tools:text="PROMPTS LIST PAGE" />
+
+    <!-- Loading, Empty, Error -->
+    <org.wordpress.android.ui.ActionableEmptyView
+        android:id="@+id/actionable_empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        app:aevImage="@drawable/img_illustration_empty_results_216dp"
+        app:aevTitle="@string/blogging_prompts_state_empty_title"
+        app:aevSubtitle="@string/blogging_prompts_state_error_subtitle"
+        tools:visibility="visible" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4106,6 +4106,12 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_tab_all">All</string>
     <string name="blogging_prompts_tab_answered">Answered</string>
     <string name="blogging_prompts_tab_not_answered">Not Answered</string>
+    <string name="blogging_prompts_state_loading_title">Loading prompts…</string>
+    <string name="blogging_prompts_state_empty_title">No prompts yet</string>
+    <string name="blogging_prompts_state_error_title">Oops</string>
+    <string name="blogging_prompts_state_error_subtitle">There was an error loading prompts.</string>
+    <string name="blogging_prompts_state_no_connection_title">Unable to load this content right now</string>
+    <string name="blogging_prompts_state_no_connection_subtitle">Check your network connection and try again.</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>


### PR DESCRIPTION
Fixes #17125 

This PR introduces the Loading, Error, Empty and No Connection views to the Prompts List Screen.

**To test:**
- Follow test instructions as explained in previous PRs: #2, #5
- Click on any of the tabs to see the `LOADING` view for 2 seconds
- Click on the _All_ tab to see the `EMPTY` view.
- Click on the _Not Answered_ tab to see the `ERROR` view.
- Click on the _Answered_ tab to see the `NO CONNECTION` view.

**Screenshots**
| LOADING| EMPTY | ERROR | NO CONNECTION |
| ----------- | ----------- | ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/2140539/194928122-6ad224ff-b241-4fc6-bdf0-2f8303a0eb07.png) | ![image](https://user-images.githubusercontent.com/2140539/194772119-c48426dc-3043-43cb-85db-30f83f8733ef.png) | ![image](https://user-images.githubusercontent.com/2140539/194772096-6c645396-f713-4bb1-a3ad-53a1c57ae00f.png)| ![image](https://user-images.githubusercontent.com/2140539/194772104-eac29957-f574-441f-951b-479c7d97d3fb.png) |

## Regression Notes
1. Potential unintended areas of impact
- Since this is a UI change, only the Prompts List Screen should be affected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manually tested the flow of opening Prompts List Screen and verifying UI and UX
- Unit Tests were run to check for regression

3. What automated tests I added (or what prevented me from doing so)
- No unit tests were added since this was a purely UI change

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
