### PR TITLE
Add blogging prompt list item view and adapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListAdapter.kt
@@ -2,15 +2,13 @@ package org.wordpress.android.ui.bloggingprompts
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.Callback
 import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.BloggingPromptsListItemBinding
+import org.wordpress.android.util.extensions.getQuantityString
 import org.wordpress.android.util.extensions.setVisible
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 class BloggingPromptsListAdapter() : RecyclerView.Adapter<BloggingPromptsListItemViewHolder>() {
     private var items = listOf<BloggingPromptsListItem>()
@@ -45,17 +43,13 @@ class BloggingPromptsListItemViewHolder(
     fun bind(prompt: BloggingPromptsListItem) {
         with(binding) {
             promptTitle.text = prompt.title
-            promptSubtitleAnswerCount.text =
-                    when (prompt.respondentsCount) {
-                        0 -> binding.root.context.getString(R.string.blogging_prompts_list_item_count_answers_zero)
-                        1 -> binding.root.context.getString(R.string.blogging_prompts_list_item_count_answers_one)
-                        else -> binding.root.context.getString(
-                                R.string.blogging_prompts_list_item_count_answers_many,
-                                prompt.respondentsCount
-                        )
-                    }
-            promptSubtitleDate.text =
-                    SimpleDateFormat("MMM d", Locale.getDefault()).format(prompt.date)
+            promptSubtitleAnswerCount.text = root.getQuantityString(
+                    prompt.respondentsCount,
+                    R.string.blogging_prompts_list_item_count_answers_zero,
+                    R.string.blogging_prompts_list_item_count_answers_one,
+                    R.string.blogging_prompts_list_item_count_answers_many
+            )
+            promptSubtitleDate.text = prompt.dateLabel
             groupAnsweredLabel.setVisible(prompt.isAnswered)
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListAdapter.kt
@@ -1,0 +1,77 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.DiffUtil.Callback
+import androidx.recyclerview.widget.RecyclerView
+import org.wordpress.android.R
+import org.wordpress.android.databinding.BloggingPromptsListItemBinding
+import org.wordpress.android.util.extensions.setVisible
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class BloggingPromptsListAdapter() : RecyclerView.Adapter<BloggingPromptsListItemViewHolder>() {
+    private var items = listOf<BloggingPromptsListItem>()
+
+    fun update(newItems: List<BloggingPromptsListItem>) {
+        val diffResult = DiffUtil.calculateDiff(
+                BloggingPromptsListDiffCallback(
+                        items,
+                        newItems
+                )
+        )
+        items = newItems
+        diffResult.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BloggingPromptsListItemViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val binding = BloggingPromptsListItemBinding.inflate(layoutInflater, parent, false)
+        return BloggingPromptsListItemViewHolder(binding)
+    }
+
+    override fun getItemCount() = items.size
+
+    override fun onBindViewHolder(holder: BloggingPromptsListItemViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+}
+
+class BloggingPromptsListItemViewHolder(
+    private val binding: BloggingPromptsListItemBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(prompt: BloggingPromptsListItem) {
+        with(binding) {
+            promptTitle.text = prompt.title
+            promptSubtitleAnswerCount.text =
+                    when (prompt.respondentsCount) {
+                        0 -> binding.root.context.getString(R.string.blogging_prompts_list_item_count_answers_zero)
+                        1 -> binding.root.context.getString(R.string.blogging_prompts_list_item_count_answers_one)
+                        else -> binding.root.context.getString(
+                                R.string.blogging_prompts_list_item_count_answers_many,
+                                prompt.respondentsCount
+                        )
+                    }
+            promptSubtitleDate.text =
+                    SimpleDateFormat("MMM d", Locale.getDefault()).format(prompt.date)
+            groupAnsweredLabel.setVisible(prompt.isAnswered)
+        }
+    }
+}
+
+internal class BloggingPromptsListDiffCallback(
+    val old: List<BloggingPromptsListItem>,
+    val new: List<BloggingPromptsListItem>
+) : Callback() {
+    override fun getOldListSize(): Int = old.size
+
+    override fun getNewListSize(): Int = new.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            old[oldItemPosition] == new[newItemPosition]
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            old[oldItemPosition] == new[newItemPosition]
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
@@ -34,6 +34,7 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
         initializeViews()
 
         // DUMMY LOGIC
+        showEmpty()
         showLoading()
         binding.root.postDelayed(Runnable {
             if (!isAdded) return@Runnable
@@ -58,11 +59,11 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
     }
 
     private fun initializeViews() {
-        with(binding) {
-            promptsList.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-            promptsList.addItemDecoration(DividerItemDecoration(context, LinearLayout.VERTICAL))
+        with(binding.promptsList) {
+            layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+            addItemDecoration(DividerItemDecoration(context, LinearLayout.VERTICAL))
             promptsListAdapter = BloggingPromptsListAdapter()
-            promptsList.adapter = promptsListAdapter
+            adapter = promptsListAdapter
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListFragment.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import org.wordpress.android.R
 import org.wordpress.android.databinding.BloggingPromptsListFragmentBinding
 import org.wordpress.android.ui.ViewPagerFragment
@@ -13,8 +17,9 @@ import java.util.concurrent.TimeUnit
 
 class BloggingPromptsListFragment : ViewPagerFragment() {
     private lateinit var binding: BloggingPromptsListFragmentBinding
+    private lateinit var promptsListAdapter: BloggingPromptsListAdapter
 
-    override fun getScrollableViewForUniqueIdProvision(): View = binding.tempText
+    override fun getScrollableViewForUniqueIdProvision(): View = binding.promptsList
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = BloggingPromptsListFragmentBinding.inflate(inflater)
@@ -26,31 +31,52 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
 
         val section = arguments?.getSerializable(LIST_TYPE) as? PromptSection
                 ?: PromptSection.ALL
-        binding.tempText.text = section.name
-        showContent()
+        initializeViews()
 
         // DUMMY LOGIC
         showLoading()
         binding.root.postDelayed(Runnable {
             if (!isAdded) return@Runnable
             when (section) {
-                PromptSection.ALL -> showEmpty()
+                PromptSection.ALL -> showContent(
+                        listOf(
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData(),
+                                generateDummyData()
+                        )
+                )
                 PromptSection.NOT_ANSWERED -> showError()
                 PromptSection.ANSWERED -> showNoConnection()
             }.exhaustive
         }, TimeUnit.SECONDS.toMillis(2))
     }
 
-    private fun showContent() {
+    private fun initializeViews() {
         with(binding) {
-            tempText.setVisible(true)
+            promptsList.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+            promptsList.addItemDecoration(DividerItemDecoration(context, LinearLayout.VERTICAL))
+            promptsListAdapter = BloggingPromptsListAdapter()
+            promptsList.adapter = promptsListAdapter
+        }
+    }
+
+    private fun showContent(list: List<BloggingPromptsListItem>) {
+        with(binding) {
+            promptsListAdapter.update(list)
+            promptsList.setVisible(true)
             actionableEmptyView.setVisible(false)
         }
     }
 
     private fun showEmpty() {
         with(binding) {
-            tempText.setVisible(false)
+            promptsList.setVisible(false)
             with(actionableEmptyView) {
                 setVisible(true)
                 image.apply {
@@ -68,7 +94,7 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
 
     private fun showError() {
         with(binding) {
-            tempText.setVisible(false)
+            promptsList.setVisible(false)
             with(actionableEmptyView) {
                 setVisible(true)
                 image.apply {
@@ -89,7 +115,7 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
 
     private fun showNoConnection() {
         with(binding) {
-            tempText.setVisible(false)
+            promptsList.setVisible(false)
             with(actionableEmptyView) {
                 setVisible(true)
                 image.apply {
@@ -110,7 +136,7 @@ class BloggingPromptsListFragment : ViewPagerFragment() {
 
     fun showLoading() {
         with(binding) {
-            tempText.setVisible(false)
+            promptsList.setVisible(false)
             with(actionableEmptyView) {
                 setVisible(true)
                 image.setVisible(false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListItem.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.bloggingprompts
+
+import java.util.Date
+import java.util.Random
+
+data class BloggingPromptsListItem(
+    val title: String,
+    val date: Date,
+    val respondentsCount: Int,
+    val isAnswered: Boolean
+)
+
+// DUMMY DATA
+@Suppress("MagicNumber")
+fun generateDummyData() =
+        BloggingPromptsListItem(
+                title = listOf(
+                        "Cast the move of your life.",
+                        "What was your favourite ice cream as a kid?",
+                        "When did you learn to tell time?",
+                        "If I was able to time travel just once, then what would I do with that power?"
+                )[Random().nextInt(4)],
+                date = Date(),
+                respondentsCount = listOf(200, 0, 1, 13)[Random().nextInt(4)],
+                isAnswered = listOf(true, false)[Random().nextInt(2)]
+        )

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/BloggingPromptsListItem.kt
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.bloggingprompts
 
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import java.util.Random
 
 data class BloggingPromptsListItem(
     val title: String,
-    val date: Date,
+    val dateLabel: String,
     val respondentsCount: Int,
     val isAnswered: Boolean
 )
@@ -20,7 +22,9 @@ fun generateDummyData() =
                         "When did you learn to tell time?",
                         "If I was able to time travel just once, then what would I do with that power?"
                 )[Random().nextInt(4)],
-                date = Date(),
+                dateLabel = SimpleDateFormat(PROMPT_ITEM_DATE_FORMAT, Locale.getDefault()).format(Date()),
                 respondentsCount = listOf(200, 0, 1, 13)[Random().nextInt(4)],
                 isAnswered = listOf(true, false)[Random().nextInt(2)]
         )
+
+const val PROMPT_ITEM_DATE_FORMAT = "MMM d"

--- a/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
+++ b/WordPress/src/main/java/org/wordpress/android/util/extensions/ViewExtensions.kt
@@ -83,3 +83,14 @@ fun RecyclerView.disableAnimation() {
 }
 
 fun View.getString(@StringRes stringRes: Int) = context.getString(stringRes)
+
+fun View.getQuantityString(
+    quantity: Int,
+    @StringRes zeroRes: Int,
+    @StringRes oneRes: Int,
+    @StringRes manyRes: Int
+) = when (quantity) {
+    0 -> context.getString(zeroRes)
+    1 -> context.getString(oneRes)
+    else -> context.getString(manyRes, quantity)
+}

--- a/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_fragment.xml
@@ -2,17 +2,18 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <!-- Content -->
-    <TextView
-        android:id="@+id/temp_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        tools:text="PROMPTS LIST PAGE" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/prompts_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        android:visibility="gone"
+        tools:listitem="@layout/blogging_prompts_list_item"
+        tools:visibility="visible" />
 
     <!-- Loading, Empty, Error -->
     <org.wordpress.android.ui.ActionableEmptyView
@@ -21,8 +22,8 @@
         android:layout_height="match_parent"
         android:visibility="gone"
         app:aevImage="@drawable/img_illustration_empty_results_216dp"
-        app:aevTitle="@string/blogging_prompts_state_empty_title"
         app:aevSubtitle="@string/blogging_prompts_state_error_subtitle"
+        app:aevTitle="@string/blogging_prompts_state_empty_title"
         tools:visibility="visible" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/blogging_prompts_list_item.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_item.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.Group
+        android:id="@+id/group_answered_label"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:constraint_referenced_ids="prompt_subtitle_answered_separator, prompt_subtitle_answered_icon,prompt_subtitle_answered"
+        tools:visibility="visible" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_top"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="@dimen/margin_extra_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_bottom"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_end="@dimen/margin_extra_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_start"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/margin_extra_large" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_end"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/margin_extra_large" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:fontFamily="serif"
+        android:maxLines="2"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@id/guideline_start"
+        app:layout_constraintEnd_toStartOf="@id/guideline_end"
+        app:layout_constraintTop_toTopOf="@id/guideline_top"
+        tools:text="@tools:sample/lorem/random" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_subtitle_date"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        app:layout_constraintBottom_toBottomOf="@id/guideline_bottom"
+        app:layout_constraintStart_toStartOf="@+id/prompt_title"
+        app:layout_constraintTop_toBottomOf="@+id/prompt_title"
+        tools:text="Feb 16" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_subtitle_separator_answer_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="@string/blogging_prompts_list_item_separator"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        app:layout_constraintBottom_toBottomOf="@+id/prompt_subtitle_date"
+        app:layout_constraintStart_toEndOf="@+id/prompt_subtitle_date"
+        app:layout_constraintTop_toTopOf="@+id/prompt_subtitle_date" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_subtitle_answer_count"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        android:layout_marginStart="@dimen/margin_small"
+        app:layout_constraintBottom_toBottomOf="@+id/prompt_subtitle_separator_answer_count"
+        app:layout_constraintStart_toEndOf="@+id/prompt_subtitle_separator_answer_count"
+        app:layout_constraintTop_toTopOf="@+id/prompt_subtitle_separator_answer_count"
+        tools:text="40 answers" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_subtitle_answered_separator"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/blogging_prompts_list_item_separator"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorOnSurfaceMedium"
+        android:layout_marginStart="@dimen/margin_small"
+        app:layout_constraintBottom_toBottomOf="@+id/prompt_subtitle_answer_count"
+        app:layout_constraintStart_toEndOf="@+id/prompt_subtitle_answer_count"
+        app:layout_constraintTop_toTopOf="@+id/prompt_subtitle_answer_count"
+        app:layout_goneMarginBottom="@dimen/margin_large" />
+
+    <ImageView
+        android:id="@+id/prompt_subtitle_answered_icon"
+        android:layout_width="16dp"
+        android:layout_height="0dp"
+        android:maxLines="1"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_checkmark"
+        android:tint="?attr/wpColorSuccess"
+        android:layout_marginStart="@dimen/margin_small"
+        app:layout_constraintBottom_toBottomOf="@+id/prompt_subtitle_answered_separator"
+        app:layout_constraintStart_toEndOf="@+id/prompt_subtitle_answered_separator"
+        app:layout_constraintTop_toTopOf="@+id/prompt_subtitle_answered_separator"
+        tools:ignore="ContentDescription" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/prompt_subtitle_answered"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="@string/blogging_prompts_list_item_answered"
+        tools:text="Answered"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?attr/wpColorSuccess"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintBottom_toBottomOf="@+id/prompt_subtitle_answered_icon"
+        app:layout_constraintStart_toEndOf="@+id/prompt_subtitle_answered_icon"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_end"
+        app:layout_constraintTop_toTopOf="@+id/prompt_subtitle_answered_icon" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -4112,6 +4112,11 @@ translators: %s: Select control option value e.g: "Auto, 25%". -->
     <string name="blogging_prompts_state_error_subtitle">There was an error loading prompts.</string>
     <string name="blogging_prompts_state_no_connection_title">Unable to load this content right now</string>
     <string name="blogging_prompts_state_no_connection_subtitle">Check your network connection and try again.</string>
+    <string name="blogging_prompts_list_item_separator">·</string>
+    <string name="blogging_prompts_list_item_count_answers_zero">0 answers</string>
+    <string name="blogging_prompts_list_item_count_answers_one">1 answer</string>
+    <string name="blogging_prompts_list_item_count_answers_many">%1$d answers</string>
+    <string name="blogging_prompts_list_item_answered">Answered</string>
 
     <!-- Editor module -->
     <string name="post_content" tools:ignore="UnusedResources" a8c-src-lib="module:editor">Content</string>


### PR DESCRIPTION
Fixes #17125 

This PR introduces the UI for the Prompts List Items.

**To test:**
- Follow test instructions as explained in previous PRs: #2, #5, #6
- Verify that the UI of the prompt list items matches the requirements

**Screenshot:**
| Loading | Loaded |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/2140539/195927103-c40a967c-488d-4886-bb32-20a6afde7f07.png) |  ![image](https://user-images.githubusercontent.com/2140539/195926824-064b2e0a-5896-477c-b54a-e5cbf1dff728.png) |




## Regression Notes
1. Potential unintended areas of impact
- Purely UI change. Should not impact any other class.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing around the Prompt List flow. 

3. What automated tests I added (or what prevented me from doing so)
- None, since this was a UI change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
