### PR TITLE
Fetch prompts list and render UiState

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/ViewModelModule.java
@@ -7,6 +7,7 @@ import org.wordpress.android.ui.JetpackRemoteInstallViewModel;
 import org.wordpress.android.ui.accounts.LoginEpilogueViewModel;
 import org.wordpress.android.ui.accounts.LoginViewModel;
 import org.wordpress.android.ui.activitylog.list.filter.ActivityLogTypeFilterViewModel;
+import org.wordpress.android.ui.bloggingprompts.list.BloggingPromptsListViewModel;
 import org.wordpress.android.ui.bloggingprompts.onboarding.BloggingPromptsOnboardingViewModel;
 import org.wordpress.android.ui.bloggingreminders.BloggingRemindersViewModel;
 import org.wordpress.android.ui.comments.unified.UnifiedCommentActivityViewModel;
@@ -551,6 +552,11 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(BloggingPromptsOnboardingViewModel.class)
     abstract ViewModel bloggingPromptsOnboardingViewModel(BloggingPromptsOnboardingViewModel viewModel);
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(BloggingPromptsListViewModel.class)
+    abstract ViewModel bloggingPromptsListViewModel(BloggingPromptsListViewModel viewModel);
 
     @Binds
     @IntoMap

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListAdapter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListAdapter.kt
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
+import android.text.Html
+import android.text.Html.FROM_HTML_MODE_COMPACT
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -42,7 +44,7 @@ class BloggingPromptsListItemViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(prompt: BloggingPromptsListItem) {
         with(binding) {
-            promptTitle.text = prompt.title
+            promptTitle.text = Html.fromHtml(prompt.title, FROM_HTML_MODE_COMPACT)
             promptSubtitleAnswerCount.text = StringUtils.getQuantityString(
                     binding.root.context,
                     R.string.blogging_prompts_list_item_count_answers_zero,

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListDateFormatter.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListDateFormatter.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+class BloggingPromptsListDateFormatter @Inject constructor() {
+    fun now(): LocalDate? = LocalDate.now()
+    fun convert(localDate: LocalDate): Date? = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+    fun format(date: Date, locale: Locale = Locale.getDefault()): String =
+            SimpleDateFormat(PROMPT_ITEM_DATE_FORMAT, locale).format(date)
+}
+
+private const val PROMPT_ITEM_DATE_FORMAT = "MMM d"
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchNewUsecase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchNewUsecase.kt
@@ -1,0 +1,19 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
+import javax.inject.Inject
+
+class BloggingPromptsListFetchNewUsecase @Inject constructor(
+    private val promptsStore: BloggingPromptsStore,
+    private val dateHelper: BloggingPromptsListDateFormatter
+) {
+    suspend fun fetch(site: SiteModel) {
+        val fromLocalDate = dateHelper.now()!!.minusDays(TWO_WEEKS_IN_DAYS)
+        val fromDate = dateHelper.convert(fromLocalDate)
+        promptsStore.fetchPrompts(site, PROMPT_FETCH_LIMIT, fromDate!!)
+    }
+}
+
+internal const val TWO_WEEKS_IN_DAYS = 14L
+internal const val PROMPT_FETCH_LIMIT = 20

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchStoredUsecase.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchStoredUsecase.kt
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
+import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
+import javax.inject.Inject
+
+class BloggingPromptsListFetchStoredUsecase @Inject constructor(
+    private val promptsStore: BloggingPromptsStore
+) {
+    fun fetch(site: SiteModel, promptSection: PromptSection): Flow<List<BloggingPromptModel>?> =
+            promptsStore.getPrompts(site)
+                    .map { it.model }
+                    .map { filterBySection(list = it, promptSection) }
+
+    private fun filterBySection(
+        list: List<BloggingPromptModel>?,
+        promptSection: PromptSection
+    ): List<BloggingPromptModel>? =
+            list?.filter { model ->
+                when (promptSection) {
+                    PromptSection.ANSWERED -> model.isAnswered
+                    PromptSection.NOT_ANSWERED -> !model.isAnswered
+                    PromptSection.ALL -> true
+                }
+            }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFragment.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFragment.kt
@@ -8,7 +8,7 @@ import android.widget.LinearLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,14 +21,17 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class BloggingPromptsListFragment : ViewPagerFragment() {
-
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var uiHelpers: UiHelpers
 
     private lateinit var binding: BloggingPromptsListFragmentBinding
     private lateinit var promptsListAdapter: BloggingPromptsListAdapter
 
     private val parentViewModel: BloggingPromptsListParentViewModel by activityViewModels()
-    private val viewModel: BloggingPromptsListViewModel by viewModels()
+    private val viewModel: BloggingPromptsListViewModel by lazy {
+        ViewModelProvider(this@BloggingPromptsListFragment, viewModelFactory)
+                .get(BloggingPromptsListViewModel::class.java)
+    }
 
     override fun getScrollableViewForUniqueIdProvision(): View = binding.promptsList
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItem.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItem.kt
@@ -1,30 +1,8 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.Random
-
 data class BloggingPromptsListItem(
     val title: String,
     val dateLabel: String,
     val respondentsCount: Int,
     val isAnswered: Boolean
 )
-
-// DUMMY DATA
-@Suppress("MagicNumber")
-fun generateDummyData() =
-        BloggingPromptsListItem(
-                title = listOf(
-                        "Cast the move of your life.",
-                        "What was your favourite ice cream as a kid?",
-                        "When did you learn to tell time?",
-                        "If I was able to time travel just once, then what would I do with that power?"
-                )[Random().nextInt(4)],
-                dateLabel = SimpleDateFormat(PROMPT_ITEM_DATE_FORMAT, Locale.getDefault()).format(Date()),
-                respondentsCount = listOf(200, 0, 1, 13)[Random().nextInt(4)],
-                isAnswered = listOf(true, false)[Random().nextInt(2)]
-        )
-
-const val PROMPT_ITEM_DATE_FORMAT = "MMM d"

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapper.kt
@@ -1,13 +1,10 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
 import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class BloggingPromptsListItemMapper @Inject constructor(
-    private val dateFormatter: PromptDateFormatter
+    private val dateFormatter: BloggingPromptsListDateFormatter
 ) {
     fun toUiModel(domainModel: BloggingPromptModel): BloggingPromptsListItem {
         return BloggingPromptsListItem(
@@ -18,10 +15,3 @@ class BloggingPromptsListItemMapper @Inject constructor(
         )
     }
 }
-
-class PromptDateFormatter @Inject constructor() {
-    fun format(date: Date, locale: Locale = Locale.getDefault()): String =
-            SimpleDateFormat(PROMPT_ITEM_DATE_FORMAT, locale).format(date)
-}
-
-private const val PROMPT_ITEM_DATE_FORMAT = "MMM d"

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapper.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapper.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+class BloggingPromptsListItemMapper @Inject constructor(
+    private val dateFormatter: PromptDateFormatter
+) {
+    fun toUiModel(domainModel: BloggingPromptModel): BloggingPromptsListItem {
+        return BloggingPromptsListItem(
+                title = domainModel.text,
+                dateLabel = dateFormatter.format(domainModel.date),
+                respondentsCount = domainModel.respondentsCount,
+                isAnswered = domainModel.isAnswered
+        )
+    }
+}
+
+class PromptDateFormatter @Inject constructor() {
+    fun format(date: Date, locale: Locale = Locale.getDefault()): String =
+            SimpleDateFormat(PROMPT_ITEM_DATE_FORMAT, locale).format(date)
+}
+
+private const val PROMPT_ITEM_DATE_FORMAT = "MMM d"

--- a/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModel.kt
@@ -1,31 +1,39 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
 import androidx.annotation.StringRes
-import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import org.wordpress.android.R
 import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.modules.UI_THREAD
 import org.wordpress.android.ui.bloggingprompts.list.PromptSection.ALL
 import org.wordpress.android.ui.bloggingprompts.list.PromptSection.ANSWERED
 import org.wordpress.android.ui.bloggingprompts.list.PromptSection.NOT_ANSWERED
+import org.wordpress.android.viewmodel.ScopedViewModel
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class BloggingPromptsListParentViewModel @Inject constructor(
+    @Named(UI_THREAD) private val defaultDispatcher: CoroutineDispatcher,
     private val provider: BloggingPromptsListSiteProvider,
+    private val fetchNewUsecase: BloggingPromptsListFetchNewUsecase,
     private val analyticsTracker: BloggingPromptsListAnalyticsTracker,
-) : ViewModel() {
+) : ScopedViewModel(defaultDispatcher) {
     private var hasStarted = AtomicBoolean(false)
     private var lastSelectedTab = AtomicReference<PromptSection?>(null)
 
     fun start(site: SiteModel, currentTab: PromptSection) {
         provider.setSite(site)
+
         // Prevent redundant tracking during Config Changes
         if (hasStarted.get()) return
         else hasStarted.set(true)
         getSite()?.let { analyticsTracker.trackScreenShown(it, currentTab) }
+
+        fetchNewPrompts(site)
     }
 
     fun onSectionSelected(currentTab: PromptSection) {
@@ -36,6 +44,12 @@ class BloggingPromptsListParentViewModel @Inject constructor(
     }
 
     fun getSite(): SiteModel? = provider.getSite()
+
+    private fun fetchNewPrompts(site: SiteModel) {
+        launch {
+            fetchNewUsecase.fetch(site)
+        }
+    }
 }
 
 val promptsSections = listOf(ALL, ANSWERED, NOT_ANSWERED)
@@ -47,4 +61,3 @@ enum class PromptSection(@StringRes val titleRes: Int) {
     ANSWERED(R.string.blogging_prompts_tab_answered),
     NOT_ANSWERED(R.string.blogging_prompts_tab_not_answered)
 }
-

--- a/WordPress/src/main/res/layout/blogging_prompts_list_item.xml
+++ b/WordPress/src/main/res/layout/blogging_prompts_list_item.xml
@@ -58,7 +58,7 @@
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/prompt_subtitle_date"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
         android:ellipsize="end"

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListAnalyticsTrackerTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListAnalyticsTrackerTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.bloggingprompts
+package org.wordpress.android.ui.bloggingprompts.list
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -7,9 +7,6 @@ import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_PROMPTS_LIST_ACCESSED
 import org.wordpress.android.analytics.AnalyticsTracker.Stat.BLOGGING_PROMPTS_LIST_TAB_CHANGED
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.bloggingprompts.list.BloggingPromptsListAnalyticsTracker
-import org.wordpress.android.ui.bloggingprompts.list.PromptSection
-import org.wordpress.android.ui.bloggingprompts.list.TRACKS_SELECTED_TAB
 import org.wordpress.android.util.analytics.AnalyticsTrackerWrapper
 
 class BloggingPromptsListAnalyticsTrackerTest : BaseUnitTest() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchNewUsecaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchNewUsecaseTest.kt
@@ -1,0 +1,33 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
+import java.time.LocalDate
+import java.util.Date
+
+internal class BloggingPromptsListFetchNewUsecaseTest : BaseUnitTest() {
+    private val site: SiteModel = mock()
+    private val promptsStore: BloggingPromptsStore = mock()
+    private val dateHelper: BloggingPromptsListDateFormatter = mock()
+
+    private val usecase = BloggingPromptsListFetchNewUsecase(promptsStore, dateHelper)
+
+    @Test
+    fun `should fetch prompts from 2 weeks ago`() = runBlockingTest {
+        val today = LocalDate.of(2022, 1, 15) // Feb 15th
+        val twoWeeksBefore = Date(2022, 1, 1) // Feb 1st
+        whenever(dateHelper.now()).thenReturn(today)
+        whenever(dateHelper.convert(any())).thenReturn(twoWeeksBefore)
+
+        usecase.fetch(site)
+
+        verify(promptsStore).fetchPrompts(site, PROMPT_FETCH_LIMIT, twoWeeksBefore)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchStoredUsecaseTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListFetchStoredUsecaseTest.kt
@@ -1,0 +1,93 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.fluxc.model.SiteModel
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
+import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore
+import org.wordpress.android.fluxc.store.bloggingprompts.BloggingPromptsStore.BloggingPromptsResult
+import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptModel
+
+class BloggingPromptsListFetchStoredUsecaseTest : BaseUnitTest() {
+    private val promptsStore: BloggingPromptsStore = mock()
+    private val site: SiteModel = mock()
+
+    private val usecase = BloggingPromptsListFetchStoredUsecase(promptsStore)
+
+    @Test
+    fun `Should return null if store is unable to fetch prompts`() = runBlockingTest {
+        val promptSection = PromptSection.ALL
+        whenever(promptsStore.getPrompts(site)).thenReturn(flow { emit(BloggingPromptsResult()) })
+
+        val result = usecase.fetch(site, promptSection).first()
+
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `Should return empty list if store fetch results in no prompts`() = runBlockingTest {
+        val promptSection = PromptSection.ALL
+        whenever(promptsStore.getPrompts(site)).thenReturn(flow { emit(BloggingPromptsResult(model = emptyList())) })
+
+        val result = usecase.fetch(site, promptSection).first()
+
+        assertEquals(emptyList<BloggingPromptModel>(), result)
+    }
+
+    @Test
+    fun `Should return complete list of prompts if fetch is successful`() = runBlockingTest {
+        val promptSection = PromptSection.ALL
+        val listModels = listOf(
+                getPromptModel().copy(id = 14),
+                getPromptModel().copy(id = 15)
+        )
+        whenever(promptsStore.getPrompts(site)).thenReturn(flow { emit(BloggingPromptsResult(model = listModels)) })
+
+        val result = usecase.fetch(site, promptSection).first()
+
+        assertEquals(listModels, result)
+    }
+
+    @Test
+    fun `Should return filtered list of answered prompts if fetch is successful`() = runBlockingTest {
+        val promptSection = PromptSection.ANSWERED
+        val listModels = listOf(
+                getPromptModel().copy(id = 12, isAnswered = true),
+                getPromptModel().copy(id = 13, isAnswered = true),
+                getPromptModel().copy(id = 14, isAnswered = false)
+        )
+        val expectedFilteredList = listOf(
+                getPromptModel().copy(id = 12, isAnswered = true),
+                getPromptModel().copy(id = 13, isAnswered = true)
+        )
+        whenever(promptsStore.getPrompts(site)).thenReturn(flow { emit(BloggingPromptsResult(model = listModels)) })
+
+        val result = usecase.fetch(site, promptSection).first()
+
+        assertEquals(expectedFilteredList, result)
+    }
+
+    @Test
+    fun `Should return filtered list of unanswered prompts if fetch is successful`() = runBlockingTest {
+        val promptSection = PromptSection.NOT_ANSWERED
+        val listModels = listOf(
+                getPromptModel().copy(id = 12, isAnswered = true),
+                getPromptModel().copy(id = 13, isAnswered = true),
+                getPromptModel().copy(id = 14, isAnswered = false)
+        )
+        val expectedFilteredList = listOf(
+                getPromptModel().copy(id = 14, isAnswered = false)
+        )
+        whenever(promptsStore.getPrompts(site)).thenReturn(flow { emit(BloggingPromptsResult(model = listModels)) })
+
+        val result = usecase.fetch(site, promptSection).first()
+
+        assertEquals(expectedFilteredList, result)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapperTest.kt
@@ -10,7 +10,7 @@ import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPrompt
 import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptModel
 
 class BloggingPromptsListItemMapperTest : BaseUnitTest() {
-    private val dateFormatter: PromptDateFormatter = mock()
+    private val dateFormatter: BloggingPromptsListDateFormatter = mock()
 
     private val mapper = BloggingPromptsListItemMapper(dateFormatter)
 

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapperTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListItemMapperTest.kt
@@ -1,0 +1,27 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptListItem
+import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptModel
+
+class BloggingPromptsListItemMapperTest : BaseUnitTest() {
+    private val dateFormatter: PromptDateFormatter = mock()
+
+    private val mapper = BloggingPromptsListItemMapper(dateFormatter)
+
+    @Test
+    fun `Should map a PromptModel to PromptListItem`() {
+        whenever(dateFormatter.format(any(), any())).thenReturn("Jan 3")
+        val promptModel = getPromptModel()
+        val expectedListItem = getPromptListItem()
+
+        val actualListItem = mapper.toUiModel(promptModel)
+
+        Assert.assertEquals(expectedListItem, actualListItem)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModelTest.kt
@@ -1,21 +1,30 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 
+@ExperimentalCoroutinesApi
 class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
     private val analyticsTracker: BloggingPromptsListAnalyticsTracker = mock()
     private val provider: BloggingPromptsListSiteProvider = mock()
+    private val fetchNewUsecase: BloggingPromptsListFetchNewUsecase = mock()
     private val site: SiteModel = mock()
+    private val dispatcher = TestCoroutineDispatcher()
 
     private val viewModel = BloggingPromptsListParentViewModel(
             provider = provider,
-            analyticsTracker = analyticsTracker
+            analyticsTracker = analyticsTracker,
+            fetchNewUsecase = fetchNewUsecase,
+            defaultDispatcher = dispatcher
     )
 
     @Test
@@ -23,6 +32,13 @@ class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
         viewModel.start(site, promptsSections[0])
 
         verify(provider).setSite(site)
+    }
+
+    @Test
+    fun `Should fetch new prompts when started`() = runBlockingTest {
+        viewModel.start(site, promptsSections[0])
+
+        verify(fetchNewUsecase).fetch(site)
     }
 
     @Test
@@ -51,5 +67,29 @@ class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
         assertEquals(PromptSection.ALL, promptsSections[0])
         assertEquals(PromptSection.ANSWERED, promptsSections[1])
         assertEquals(PromptSection.NOT_ANSWERED, promptsSections[2])
+    }
+
+    @Test
+    fun `Should not track screen accessed if the page is already started`() {
+        whenever(provider.getSite()).thenReturn(site)
+        val promptSection = promptsSections[1]
+
+        viewModel.start(site, promptSection)
+        viewModel.start(site, promptSection)
+        viewModel.start(site, promptSection)
+
+        verify(analyticsTracker, times(1)).trackScreenShown(site, promptSection)
+    }
+
+    @Test
+    fun `Should not track tab selected if already on same tab`() {
+        whenever(provider.getSite()).thenReturn(site)
+
+        val promptSection = promptsSections[2]
+        viewModel.onSectionSelected(promptSection)
+        viewModel.onSectionSelected(promptSection)
+        viewModel.onSectionSelected(promptSection)
+
+        verify(analyticsTracker, times(1)).trackTabSelected(site, promptSection)
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListParentViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.bloggingprompts
+package org.wordpress.android.ui.bloggingprompts.list
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -7,11 +7,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
-import org.wordpress.android.ui.bloggingprompts.list.BloggingPromptsListAnalyticsTracker
-import org.wordpress.android.ui.bloggingprompts.list.BloggingPromptsListParentViewModel
-import org.wordpress.android.ui.bloggingprompts.list.BloggingPromptsListSiteProvider
-import org.wordpress.android.ui.bloggingprompts.list.PromptSection
-import org.wordpress.android.ui.bloggingprompts.list.promptsSections
 
 class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
     private val analyticsTracker: BloggingPromptsListAnalyticsTracker = mock()
@@ -25,17 +20,17 @@ class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
 
     @Test
     fun `Should save siteModel when started`() {
-        viewModel.start(site)
+        viewModel.start(site, promptsSections[0])
 
         verify(provider).setSite(site)
     }
 
     @Test
-    fun `Should track screen accessed when page opened`() {
+    fun `Should track screen accessed when started`() {
         whenever(provider.getSite()).thenReturn(site)
 
-        val promptSection = promptsSections[0]
-        viewModel.onOpen(promptSection)
+        val promptSection = promptsSections[1]
+        viewModel.start(site, promptSection)
 
         verify(analyticsTracker).trackScreenShown(site, promptSection)
     }

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListViewModelTest.kt
@@ -1,29 +1,136 @@
 package org.wordpress.android.ui.bloggingprompts.list
 
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.wordpress.android.BaseUnitTest
 import org.wordpress.android.fluxc.model.SiteModel
 import org.wordpress.android.ui.bloggingprompts.list.PromptSection.ALL
+import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptListItem
+import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptModel
+import org.wordpress.android.util.NetworkUtilsWrapper
 
-class BloggingPromptsListParentViewModelTest : BaseUnitTest() {
-
+class BloggingPromptsListViewModelTest : BaseUnitTest() {
     private val site: SiteModel = mock()
+    private val mainDispatcher = TestCoroutineDispatcher()
+    private val fetchUsecase: BloggingPromptsListFetchStoredUsecase = mock()
+    private val networkUtilsWrapper: NetworkUtilsWrapper = mock()
+    private val mapper: BloggingPromptsListItemMapper = mock()
+    val observer = mock<Observer<UiState>>()
 
-    private val viewModel = BloggingPromptsListViewModel()
+    private val viewModel = BloggingPromptsListViewModel(
+            mainDispatcher,
+            fetchUsecase,
+            networkUtilsWrapper,
+            mapper
+    )
 
     @Test
-    fun `Should show Error view if siteModel is null`() {
-        viewModel.onOpen(site = null, section = ALL)
+    fun `When opening page, Should show Error view if siteModel is null`() {
+        viewModel.onOpen(siteModel = null, section = ALL)
 
         assertEquals(ErrorViewState.Error, viewModel.uiState.value?.errorViewState)
         assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
     }
 
     @Test
-    fun `Should show Error view if section null`() {
-        viewModel.onOpen(site = site, section = null)
+    fun `When opening page, Should show Error view if section null`() {
+        viewModel.onOpen(siteModel = site, section = null)
+
+        assertEquals(ErrorViewState.Error, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When clicking retry button, Should show Error view if siteModel is null`() {
+        viewModel.onClickButtonRetry()
+
+        assertEquals(ErrorViewState.Error, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When clicking retry button, Should show Loading view before fetching`() {
+        viewModel.onOpen(site, ALL)
+        viewModel.uiState.observeForever(observer)
+
+        viewModel.onClickButtonRetry()
+
+        verify(observer).onChanged(UiState(ContentViewState.Hidden, ErrorViewState.Loading))
+    }
+
+    @Test
+    fun `When opening page, Should show Loading view before fetching`() {
+        viewModel.uiState.observeForever(observer)
+        viewModel.onOpen(site, ALL)
+
+        verify(observer).onChanged(UiState(ContentViewState.Hidden, ErrorViewState.Loading))
+    }
+
+    @Test
+    fun `When opening page, Should show NoConnection view if network unavailable`() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(false)
+
+        viewModel.onOpen(site, ALL)
+
+        assertEquals(ErrorViewState.NoConnection, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When opening page, Should show Error view if prompt fetch fails`() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(fetchUsecase.fetch(eq(site), any())).thenReturn(flow { emit(null) })
+
+        viewModel.onOpen(site, ALL)
+
+        assertEquals(ErrorViewState.Error, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When opening page, Should show Empty view if prompt fetch fails`() {
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(fetchUsecase.fetch(eq(site), any())).thenReturn(flow { emit(emptyList()) })
+
+        viewModel.onOpen(site, ALL)
+
+        assertEquals(ErrorViewState.Empty, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When opening page, Should show Content view if prompt fetch and mapping succeeds`() {
+        val listModels = listOf(getPromptModel())
+        val listItems = listOf(getPromptListItem())
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(fetchUsecase.fetch(eq(site), any())).thenReturn(flow { emit(listModels) })
+        whenever(mapper.toUiModel(any())).thenReturn(listItems[0])
+
+        viewModel.onOpen(site, ALL)
+
+        assertEquals(ErrorViewState.Hidden, viewModel.uiState.value?.errorViewState)
+        assertEquals(ContentViewState.Content(listItems), viewModel.uiState.value?.contentViewState)
+    }
+
+    @Test
+    fun `When opening page, Should show Error view if fetch succeeds but mapping fails`() {
+        val listItems = listOf(
+                getPromptModel(),
+                getPromptModel()
+        )
+        whenever(networkUtilsWrapper.isNetworkAvailable()).thenReturn(true)
+        whenever(fetchUsecase.fetch(eq(site), any())).thenReturn(flow { emit(listItems) })
+        whenever(mapper.toUiModel(listItems[1])).thenThrow(IllegalStateException())
+
+        viewModel.onOpen(site, ALL)
 
         assertEquals(ErrorViewState.Error, viewModel.uiState.value?.errorViewState)
         assertEquals(ContentViewState.Hidden, viewModel.uiState.value?.contentViewState)

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListViewModelTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/BloggingPromptsListViewModelTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.Assert.assertEquals
@@ -17,6 +18,7 @@ import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPrompt
 import org.wordpress.android.ui.bloggingprompts.list.TestDummyProvider.getPromptModel
 import org.wordpress.android.util.NetworkUtilsWrapper
 
+@ExperimentalCoroutinesApi
 class BloggingPromptsListViewModelTest : BaseUnitTest() {
     private val site: SiteModel = mock()
     private val mainDispatcher = TestCoroutineDispatcher()

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/PromptDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/PromptDateFormatterTest.kt
@@ -7,7 +7,7 @@ import java.util.Date
 import java.util.Locale
 
 internal class PromptDateFormatterTest : BaseUnitTest() {
-    private val promptDateFormatter = PromptDateFormatter()
+    private val promptDateFormatter = BloggingPromptsListDateFormatter()
 
     @Test
     fun `Should format date provided`() {

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/PromptDateFormatterTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/PromptDateFormatterTest.kt
@@ -1,0 +1,20 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.wordpress.android.BaseUnitTest
+import java.util.Date
+import java.util.Locale
+
+internal class PromptDateFormatterTest : BaseUnitTest() {
+    private val promptDateFormatter = PromptDateFormatter()
+
+    @Test
+    fun `Should format date provided`() {
+        val date = Date(2022, 0, 7)
+
+        val dateLabel = promptDateFormatter.format(date, locale = Locale.UK)
+
+        assertEquals("Jan 7", dateLabel)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/TestDummyProvider.kt
+++ b/WordPress/src/test/java/org/wordpress/android/ui/bloggingprompts/list/TestDummyProvider.kt
@@ -1,0 +1,26 @@
+package org.wordpress.android.ui.bloggingprompts.list
+
+import org.wordpress.android.fluxc.model.bloggingprompts.BloggingPromptModel
+import java.time.LocalDate
+import java.util.Date
+
+object TestDummyProvider {
+    fun getPromptModel() = BloggingPromptModel(
+            id = 12,
+            text = "What did you do last week?",
+            title = "PN2",
+            content = "brief description",
+            date = Date(LocalDate.of(2022, 1, 3).toEpochDay()),
+            isAnswered = true,
+            attribution = "asdf",
+            respondentsCount = 12,
+            respondentsAvatarUrls = emptyList()
+    )
+
+    fun getPromptListItem() = BloggingPromptsListItem(
+            title = "What did you do last week?",
+            dateLabel = "Jan 3",
+            respondentsCount = 12,
+            isAnswered = true
+    )
+}


### PR DESCRIPTION
Fixes #17125 

This PR introduces the following changes:
- Adds usecase to fetch new prompts whenever the Prompts List page is opened. The current logic is to set the start date to 2 weeks before now. This is then stored. 
- Adds usecase to fetch the stored prompts from the db and render the appropriate state based on the data available. 
- Adds mappers to convert the Domain model to the UI model (ListItem)


**To test:**
- Follow test instructions as explained in previous PRs: #2, #5, #6, #7, #8, #9
- There are no new UI changes in this PR. However, all dummy data and logic has been removed to rely on API response (or db) data. Ensure the right information is shown with the existing UI states. 

**Screenshot**
![image](https://user-images.githubusercontent.com/2140539/197618337-e748333f-5701-4456-afc2-d7fbf3765afe.png)


## Regression Notes
1. Potential unintended areas of impact
- Dummy data providers have been replaced with actual data fetched from APIs and DB. Ensure the UI is matching with actual data. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Test the original flows manually
- Run all unit tests

3. What automated tests I added (or what prevented me from doing so)
- Unit Tests were added for mappers, usecases, helpers and viewmodels. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
